### PR TITLE
removing linux command

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,6 @@ pipeline{
         stage('1-clone code or build'){
             steps{
                 sh 'du -h'
-                sh'os-release'
                 }
          }
          stage('2-memorycheck'){


### PR DESCRIPTION
I removed

- cat os-release command 
- cat etc/systemd/system 

Both are linux commands that reference system partition that are not on the Jenkins Server